### PR TITLE
Changing selection.empty() to be selection.html(null)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -343,7 +343,7 @@ export default function milestones(selector) {
           const above = isAbove(d.index);
 
           const element = dom.select(this);
-          element.empty();
+          element.html(null);
 
           if (!above) {
             element.append('span')


### PR DESCRIPTION
selection.empty checks if it contains no elements. selection.html with a null value will clear the contents of node.

Fixes issue #6.