### PR TITLE
Labels as links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ npm-debug.log
 .vscode
 .source.*.html
 build/
-.tool-versions

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 .vscode
 .source.*.html
 build/
+.tool-versions

--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,7 @@ export default function milestones(selector) {
     entries: undefined,
     timestamp: 'timestamp',
     text: 'text',
+    url: undefined,
   };
   function assignMapping(d) {
     mapping = Object.assign(mapping, d);
@@ -367,6 +368,12 @@ export default function milestones(selector) {
                 .classed('milestones-image-label', true)
                 .attr('height', '100')
                 .attr('src', t);
+            } else if (v[mapping.url]) {
+              item = element
+                .append('a')
+                .classed('milestones-label', true)
+                .classed('milestones-link-label', true)
+                .attr('href', v[mapping.url]);
             } else {
               item = element
                 .append('span')

--- a/src/main.js
+++ b/src/main.js
@@ -373,7 +373,8 @@ export default function milestones(selector) {
                 .append('a')
                 .classed('milestones-label', true)
                 .classed('milestones-link-label', true)
-                .attr('href', v[mapping.url]);
+                .attr('href', v[mapping.url])
+                .text(t);
             } else {
               item = element
                 .append('span')

--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,7 @@ export default function milestones(selector) {
     entries: undefined,
     timestamp: 'timestamp',
     text: 'text',
-    url: undefined,
+    url: 'url',
   };
   function assignMapping(d) {
     mapping = Object.assign(mapping, d);


### PR DESCRIPTION
Allow for creation of `a` tags instead of `span` when a url is added for each node in the dataset
this allows for standard click/middleclick experience which otherwise needs `onEventClick` handler 