### PR TITLE
Add Support for Ordinal Scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [`main`](https://github.com/walterra/d3-milestones/tree/main)
 
+- Added support for ordinal scales as an alternative to time scales. ([#15](https://github.com/walterra/d3-milestones/issues/15))
 - Add `renderCallback()` method to apply customizations after rendering is complete. ([#79](https://github.com/walterra/d3-milestones/issues/79))
 - Added support for custom HTML ID attributes for milestone elements. ([#78](https://github.com/walterra/d3-milestones/issues/78))
 - Added WebP format to the list of supported image formats.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Examples are included using storybook:
 - [Vikings Timeline](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--vikings)
 - [Windows/macOS Timeline](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--os-category-labels)
 - [Ordinal Scale Example](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--ordinal-scale-example) - Demonstrates using an ordinal scale instead of time scale
+- [Ordinal Scale with Categories](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--ordinal-scale-categories-example) - Shows how to use ordinal scales with multiple categories
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Examples are included using storybook:
 
 - [Vikings Timeline](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--vikings)
 - [Windows/macOS Timeline](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--os-category-labels)
+- [Ordinal Scale Example](https://walterra.github.io/d3-milestones/?path=/story/d3-milestones--ordinal-scale-example) - Demonstrates using an ordinal scale instead of time scale
 
 ## API Reference
 
@@ -82,7 +83,8 @@ Sets overrides for the default attributes for the expected data structure of an 
   {
     category: undefined,
     entries: undefined,
-    timestamp: 'timestamp',
+    timestamp: 'timestamp',  // Used only for time based scales
+    value: 'value',          // Used only for ordinal scale values
     text: 'text',
     url: 'url',
     id: 'id'
@@ -109,6 +111,13 @@ Enables/Disables auto resizing. Enabled by default, this adds listeners to resiz
 <a name="orientation" href="#orientation">#</a> vis.<b>orientation</b>(<i>string</i>)
 
 Sets the orientation of the timeline, can be either `horizontal` or `vertical`. Defaults to `horizontal`.
+
+<a name="scaleType" href="#scaleType">#</a> vis.<b>scaleType</b>(<i>string</i>)
+
+Sets the scale type of the timeline, can be either `time` or `ordinal`. Defaults to `time`.
+
+- `time`: Uses a time scale for chronological data with timestamps
+- `ordinal`: Uses an ordinal scale for categorical data without timestamps
 
 <a name="parseTime" href="#parseTime">#</a> vis.<b>parseTime</b>(<i>specifier</i>)
 

--- a/src/_defaults.js
+++ b/src/_defaults.js
@@ -2,10 +2,12 @@ export const DEFAULTS = {
   DISTRIBUTION: 'top-bottom',
   OPTIMIZE: false,
   ORIENTATION: 'horizontal',
+  SCALE_TYPE: 'time',
   MAPPING: {
     category: undefined,
     entries: undefined,
-    timestamp: 'timestamp',
+    timestamp: 'timestamp', // Used only for time based scales
+    value: 'value', // Used only for ordinal scale values
     text: 'text',
     url: 'url',
     id: 'id',

--- a/src/_get_available_width.js
+++ b/src/_get_available_width.js
@@ -18,7 +18,8 @@ export const getAvailableWidth = (
   textMerge,
   width,
   x,
-  useNext = true
+  useNext = true,
+  scaleType = 'time' // Default to time scale if not provided
 ) => {
   // get the available width until the uber-next group
   let nextTestIndex =
@@ -51,7 +52,11 @@ export const getAvailableWidth = (
   let availableWidth = getAttribute(currentNode, offsetCheckAttribute);
 
   if (typeof uberNextItem !== 'undefined') {
-    const offsetUberNextItem = x(aggregateFormatParse(uberNextItem.key));
+    const value =
+      scaleType === 'ordinal'
+        ? uberNextItem.key
+        : aggregateFormatParse(uberNextItem.key);
+    const offsetUberNextItem = x(value);
 
     if ((orientation === 'horizontal') & useNext) {
       availableWidth = offsetUberNextItem - offset - labelRightMargin;

--- a/src/_optimize.js
+++ b/src/_optimize.js
@@ -35,7 +35,8 @@ export const optimize = (
   textMerge,
   width,
   widthAttribute,
-  x
+  x,
+  scaleType = 'time' // Default to time scale if not provided
 ) => {
   const nestedNodes = nest()
     .key((d) => {
@@ -59,7 +60,9 @@ export const optimize = (
           orientation === 'horizontal' ? nodes.length - d.index - 1 : d.index;
 
         const item = dom.selectAll(nodes[index]).data()[0];
-        const offset = x(aggregateFormatParse(item.key));
+        const value =
+          scaleType === 'ordinal' ? item.key : aggregateFormatParse(item.key);
+        const offset = x(value);
         const currentNode = nodes[index][0];
 
         let isLast = index === nodes.length - 1;
@@ -178,7 +181,8 @@ export const optimize = (
                 textMerge,
                 width,
                 x,
-                useNext
+                useNext,
+                scaleType // Pass scale type to getAvailableWidth
               );
             }
           } while (
@@ -221,8 +225,11 @@ export const optimize = (
                 return;
               }
 
-              let overlapCheckOffset =
-                x(aggregateFormatParse(overlapCheckItem.key)) - 5;
+              const overlapValue =
+                scaleType === 'ordinal'
+                  ? overlapCheckItem.key
+                  : aggregateFormatParse(overlapCheckItem.key);
+              let overlapCheckOffset = x(overlapValue) - 5;
               const overlapItemOffsetAnchor = overlapCheckOffset;
               const overlapCheckDomElement = dom.selectAll(
                 nodes[overlapCheckIndex]

--- a/src/_transform.js
+++ b/src/_transform.js
@@ -1,9 +1,22 @@
 import { ascending } from 'd3-array';
 import { nest } from 'd3-collection';
 
-export function transform(aggregateFormat, data, mapping, parseTime) {
+export function transform(
+  aggregateFormat,
+  data,
+  mapping,
+  parseTime,
+  scaleType = 'time'
+) {
+  // Choose grouping function based on scale type
   const groupBy = function (d) {
-    return aggregateFormat(parseTime(d[mapping.timestamp]));
+    if (scaleType === 'ordinal') {
+      // For ordinal scales, use the value field directly
+      return d[mapping.value];
+    } else {
+      // For time scales, use the timestamp with formatting
+      return aggregateFormat(parseTime(d[mapping.timestamp]));
+    }
   };
 
   // test for different data structures

--- a/src/_transform.js
+++ b/src/_transform.js
@@ -40,6 +40,7 @@ export function transform(
     return nested.map((d, dI) => {
       d.index = dI;
       d.timelineIndex = tI;
+      d.scaleType = scaleType; // Pass the scale type to the data object
       return d;
     });
   }

--- a/src/main.js
+++ b/src/main.js
@@ -262,7 +262,10 @@ export default function milestones(selector) {
     // Create the appropriate scale based on scaleType
     const x =
       scaleType === 'ordinal'
-        ? scale.scalePoint().range([0, width]).domain(allKeys)
+        ? scale
+            .scalePoint()
+            .range([0, width])
+            .domain(Array.from(new Set(allKeys))) // Use Set to ensure unique values
         : scale
             .scaleTime()
             .rangeRound([0, width])

--- a/src/main.js
+++ b/src/main.js
@@ -262,10 +262,7 @@ export default function milestones(selector) {
     // Create the appropriate scale based on scaleType
     const x =
       scaleType === 'ordinal'
-        ? scale
-            .scalePoint()
-            .range([0, width])
-            .domain(Array.from(new Set(allKeys))) // Use Set to ensure unique values
+        ? scale.scalePoint().range([0, width]).domain(allKeys) // Keep original order for ordinal scales
         : scale
             .scaleTime()
             .rangeRound([0, width])

--- a/src/main.js
+++ b/src/main.js
@@ -282,6 +282,7 @@ export default function milestones(selector) {
       .merge(group)
       .style(marginTimeAttribute, (d) => {
         // For ordinal scale, use the key directly; for time scale, parse it
+        d.scaleType = scaleType; // Ensure scale type is passed to data
         const value =
           scaleType === 'ordinal' ? d.key : aggregateFormatParse(d.key);
         return x(value) + 'px';
@@ -320,6 +321,7 @@ export default function milestones(selector) {
         .merge(text)
         .style(widthAttribute, (d) => {
           // calculate the available width
+          d.scaleType = scaleType; // Ensure scale type is passed to data
           const value =
             scaleType === 'ordinal' ? d.key : aggregateFormatParse(d.key);
           const offset = x(value);
@@ -347,6 +349,8 @@ export default function milestones(selector) {
             orientation === 'horizontal' ? previousItem : nextItem;
 
           if (typeof compareItem1 !== 'undefined') {
+            // Pass scale type to next item
+            compareItem1.scaleType = scaleType;
             const nextValue =
               scaleType === 'ordinal'
                 ? compareItem1.key
@@ -366,6 +370,8 @@ export default function milestones(selector) {
                 orientation === 'horizontal' ? width - offset : offset;
             } else if (itemNumTotal - itemNum === 0) {
               if (typeof compareItem2 !== 'undefined') {
+                // Pass scale type to previous item
+                compareItem2.scaleType = scaleType;
                 const prevValue =
                   scaleType === 'ordinal'
                     ? compareItem2.key
@@ -536,7 +542,8 @@ export default function milestones(selector) {
           textMerge,
           width,
           widthAttribute,
-          x
+          x,
+          scaleType // Pass scale type to optimizer
         );
       }
     } else {

--- a/src/stories/example-11-ordinal-scale.stories.js
+++ b/src/stories/example-11-ordinal-scale.stories.js
@@ -1,0 +1,48 @@
+import { argTypes, createMilestones } from './milestones';
+
+export default {
+  title: 'd3-milestones',
+  argTypes,
+};
+
+// Sample data for an ordinal scale timeline
+const ordinalData = [
+  {
+    step: 'Step 1',
+    detail: 'Planning phase',
+  },
+  {
+    step: 'Step 2',
+    detail: 'Research phase',
+  },
+  {
+    step: 'Step 3',
+    detail: 'Development phase',
+  },
+  {
+    step: 'Step 4',
+    detail: 'Testing phase',
+  },
+  {
+    step: 'Step 5',
+    detail: 'Deployment phase',
+  },
+];
+
+const Template = (args) =>
+  createMilestones(
+    'Ordinal Scale Example',
+    'This example demonstrates using an ordinal scale instead of time scale',
+    args
+  );
+
+export const OrdinalScaleExample = Template.bind({});
+OrdinalScaleExample.args = {
+  scaleType: 'ordinal',
+  optimize: true,
+  mapping: {
+    value: 'step',
+    text: 'detail',
+  },
+  data: ordinalData,
+};

--- a/src/stories/example-11-ordinal-scale.stories.js
+++ b/src/stories/example-11-ordinal-scale.stories.js
@@ -31,7 +31,7 @@ const ordinalData = [
 
 const Template = (args) =>
   createMilestones(
-    'Ordinal Scale Example',
+    'Ordinal Scale',
     'This example demonstrates using an ordinal scale instead of time scale',
     args
   );

--- a/src/stories/example-11-ordinal-scale.stories.js
+++ b/src/stories/example-11-ordinal-scale.stories.js
@@ -36,8 +36,8 @@ const Template = (args) =>
     args
   );
 
-export const OrdinalScaleExample = Template.bind({});
-OrdinalScaleExample.args = {
+export const OrdinalScale = Template.bind({});
+OrdinalScale.args = {
   scaleType: 'ordinal',
   optimize: true,
   mapping: {

--- a/src/stories/example-12-ordinal-scale-categories.stories.js
+++ b/src/stories/example-12-ordinal-scale-categories.stories.js
@@ -79,8 +79,8 @@ const Template = (args) =>
     args
   );
 
-export const OrdinalScaleCategoriesExample = Template.bind({});
-OrdinalScaleCategoriesExample.args = {
+export const OrdinalScaleCategories = Template.bind({});
+OrdinalScaleCategories.args = {
   scaleType: 'ordinal',
   optimize: true,
   mapping: {

--- a/src/stories/example-12-ordinal-scale-categories.stories.js
+++ b/src/stories/example-12-ordinal-scale-categories.stories.js
@@ -1,0 +1,93 @@
+import { argTypes, createMilestones } from './milestones';
+
+export default {
+  title: 'd3-milestones',
+  argTypes,
+};
+
+// Sample data for an ordinal scale timeline with categories
+const categoriesData = [
+  {
+    category: 'Frontend',
+    steps: [
+      {
+        step: 'Requirements',
+        detail: 'Gather interface requirements',
+      },
+      {
+        step: 'Wireframes',
+        detail: 'Create wireframes and mockups',
+      },
+      {
+        step: 'Implementation',
+        detail: 'Develop frontend components',
+      },
+      {
+        step: 'Testing',
+        detail: 'Test frontend components',
+      },
+    ],
+  },
+  {
+    category: 'Backend',
+    steps: [
+      {
+        step: 'Architecture',
+        detail: 'Design system architecture',
+      },
+      {
+        step: 'Database',
+        detail: 'Create database schema',
+      },
+      {
+        step: 'API',
+        detail: 'Implement API endpoints',
+      },
+      {
+        step: 'Integration',
+        detail: 'Connect frontend and backend',
+      },
+    ],
+  },
+  {
+    category: 'DevOps',
+    steps: [
+      {
+        step: 'Environment',
+        detail: 'Set up development environment',
+      },
+      {
+        step: 'CI/CD',
+        detail: 'Configure CI/CD pipeline',
+      },
+      {
+        step: 'Deployment',
+        detail: 'Prepare deployment strategy',
+      },
+      {
+        step: 'Monitoring',
+        detail: 'Set up monitoring tools',
+      },
+    ],
+  },
+];
+
+const Template = (args) =>
+  createMilestones(
+    'Ordinal Scale with Categories',
+    'This example demonstrates using an ordinal scale with multiple categories',
+    args
+  );
+
+export const OrdinalScaleCategoriesExample = Template.bind({});
+OrdinalScaleCategoriesExample.args = {
+  scaleType: 'ordinal',
+  optimize: true,
+  mapping: {
+    category: 'category',
+    entries: 'steps',
+    value: 'step',
+    text: 'detail',
+  },
+  data: categoriesData,
+};

--- a/src/stories/milestones.js
+++ b/src/stories/milestones.js
@@ -47,6 +47,10 @@ export const argTypes = {
     options: ['_blank', '_self', '_parent', '_top'],
     control: { type: 'radio' },
   },
+  scaleType: {
+    options: ['time', 'ordinal'],
+    control: { type: 'radio' },
+  },
 };
 
 export const createMilestones = (
@@ -65,6 +69,7 @@ export const createMilestones = (
     parseTime,
     autoResize,
     urlTarget,
+    scaleType,
   },
   DIV_ID = 'timeline',
   style = ''
@@ -87,6 +92,7 @@ export const createMilestones = (
     parseTime && m.parseTime(parseTime);
     autoResize && m.autoResize(autoResize);
     urlTarget && m.urlTarget(urlTarget);
+    scaleType && m.scaleType(scaleType);
 
     m.render(data);
   }


### PR DESCRIPTION
Fixes #15.

## Summary

This PR adds support for ordinal scales as an alternative to time scales, allowing visualization of categorical or sequential data that doesn't have associated timestamps.

## Features

- Added new `scaleType` option that accepts 'time' or 'ordinal' values (default: 'time')
- Added support for ordinal scale data mapping via the `value` property
- Preserved the original order of categorical data in ordinal scales
- Updated layout and optimization algorithms to work with both scale types
- Added example stories showing ordinal scales with and without categories

## Examples

The PR includes two new storybook examples:
- Basic ordinal scale example with sequential steps
- Multi-category ordinal scale example showing parallel processes

## API Changes

Added a new method to the public API:

```javascript
milestones('#timeline')
  .scaleType('ordinal')  // New setting - use ordinal scale instead of time scale
  .mapping({
    value: 'step',       // Field for ordinal position (instead of timestamp)
    text: 'detail'
  })
  .render(data);
```
