### PR TITLE
deploy storybook to github pages on release

### DIFF
--- a/.changeset/deploy-storybook-on-release.md
+++ b/.changeset/deploy-storybook-on-release.md
@@ -1,0 +1,5 @@
+---
+"d3-milestones": patch
+---
+
+Deploy Storybook to GitHub Pages automatically on release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,10 @@ jobs:
             VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
             gh release upload "v${VERSION}" build/d3-milestones.zip --clobber
           fi
+
+      - name: Deploy Storybook to GitHub Pages
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          yarn deploy-storybook


### PR DESCRIPTION
Adds Storybook deployment step to release workflow. After publishing packages, Storybook builds and deploys to GitHub Pages. Requires git configuration for commit and uses yarn deploy-storybook command.