### PR TITLE
Pin npm 11 in release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: build
 on:
   push:
+  pull_request:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '20,50 * * * *'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           cache: "yarn"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Setup Xvfb for browser tests
         run: |


### PR DESCRIPTION
## Summary

- pin the release workflow to npm 11
- prevent npm 12 from being installed on unsupported Node.js 20 runners

## Testing

- not run (workflow-only change)