### PR TITLE
Add manual CI workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: build
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '20,50 * * * *'


### PR DESCRIPTION
## Summary

- add the `workflow_dispatch` trigger to the build workflow
- allow CI runs to be started manually for any branch

## Verification

- validated workflow YAML syntax
- ran `git diff --check`