### PR TITLE
Fix duplicate CI runs and optional APM setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: build
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   schedule:

--- a/test/apm.js
+++ b/test/apm.js
@@ -1,5 +1,5 @@
 const apm =
-  typeof APM_SERVER === 'string'
+  typeof APM_SERVER === 'string' && APM_SERVER.length > 0
     ? elasticApm.init({
         serviceName: 'd3-milestones-karma-service',
         serverUrl: APM_SERVER,
@@ -14,9 +14,15 @@ export function startTransaction(spanName) {
 
   if (apm) {
     transaction = apm.startTransaction('d3-milestones/karma', 'custom');
-    transaction.addLabels({ 'd3-milestones-layout': APM_GIT_BRANCH });
-    span = transaction.startSpan(spanName, 'render-chart');
-    span.addLabels({ 'd3-milestones-layout': APM_GIT_BRANCH });
+
+    if (transaction) {
+      transaction.addLabels({ 'd3-milestones-layout': APM_GIT_BRANCH });
+      span = transaction.startSpan(spanName, 'render-chart');
+
+      if (span) {
+        span.addLabels({ 'd3-milestones-layout': APM_GIT_BRANCH });
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

- run push CI only on `main` to avoid duplicate branch and pull request checks
- skip APM initialization when the server secret is unavailable
- guard unavailable APM transactions and spans

## Checks

- `yarn lint`
- `yarn test-jest`
- `git diff --check`