### PR TITLE
Make responsive resize layout deterministic

### DIFF
--- a/.changeset/deterministic-resize-layout.md
+++ b/.changeset/deterministic-resize-layout.md
@@ -1,0 +1,5 @@
+---
+"d3-milestones": patch
+---
+
+Produce the same label layout after resizing as a fresh render at the target size

--- a/src/_optimize.js
+++ b/src/_optimize.js
@@ -153,11 +153,14 @@ export const optimize = (
 
       const padding = isAbove ? paddingAbove : paddingBelow;
 
-      // reset padding and "last" class before starting the optimization
+      // Restore the unoptimized baseline before measuring the existing nodes.
       for (const node of nodes) {
         const parentElement = getParentElement(dom.selectAll(node));
         parentElement.attr('data-adjusted', false);
         parentElement.classed(`${cssLastClass}-${orientation}`, false);
+        parentElement.style(widthAttr, null);
+        parentElement.style(paddingAbove, null);
+        parentElement.style(paddingBelow, null);
         parentElement.style(padding, isHorizontal ? '0px' : '10px');
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -261,8 +261,12 @@ export default function milestones(selector) {
     autoResize.current = d;
   }
 
+  let lastRenderData;
+
   function render(data) {
-    // Simple render method with a single data parameter
+    if (typeof data !== 'undefined') {
+      lastRenderData = data;
+    }
 
     const widthAttribute = orientation === 'horizontal' ? 'width' : 'height';
     const marginTimeAttribute =
@@ -275,8 +279,14 @@ export default function milestones(selector) {
 
     const timelineSelection = dom.select(selector).selectAll('.' + cssPrefix);
     let nestedData =
-      typeof data !== 'undefined'
-        ? transform(aggregateFormat, data, mapping, parseTime, scaleType)
+      typeof lastRenderData !== 'undefined'
+        ? transform(
+            aggregateFormat,
+            lastRenderData,
+            mapping,
+            parseTime,
+            scaleType,
+          )
         : timelineSelection.data();
 
     // Split groups by distribution if using custom distribution

--- a/src/main.test.js
+++ b/src/main.test.js
@@ -66,6 +66,25 @@ describe('milestones', () => {
     expect(timelineElement).not.toBeNull();
   });
 
+  it('should rebuild layout data from the original input on re-render', () => {
+    container.style.width = '800px';
+    const chart = milestones('#container');
+    const data = [
+      { text: 'Event 1', timestamp: '2023-01-01' },
+      { text: 'Event 2', timestamp: '2023-06-01' },
+    ];
+
+    chart.optimize(false).render(data);
+
+    const firstGroup = document.querySelector('.milestones__group');
+    const originalKey = firstGroup.__data__.key;
+    firstGroup.__data__.key = '2099-01-01';
+
+    chart.render();
+
+    expect(firstGroup.__data__.key).toBe(originalKey);
+  });
+
   it('should execute renderCallback when render is called', () => {
     const chart = milestones('#container');
     const mockCallback = jest.fn();


### PR DESCRIPTION
## Summary

- rebuild transformed layout data from the original render input during resize
- clear optimizer-owned dimensions and padding before measuring existing labels
- add regression coverage for repeat renders

### before

<img width="960" height="540" alt="d3-milestones-responsive" src="https://github.com/user-attachments/assets/8474d2d6-d619-4ad5-82ed-fc51a26dc4e4" />

### after

<img width="960" height="540" alt="d3-milestones-responsive-new" src="https://github.com/user-attachments/assets/2f2e64e5-cea7-40dd-85bc-4ad3c91234c2" />


## Testing

- `yarn lint`
- `yarn test-jest --runInBand`
- `yarn pretest && yarn test-karma`
- `yarn build`

Closes #142
