### PR TITLE
Fix Storybook GitHub Pages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,4 +97,5 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          yarn build-storybook
           yarn deploy-storybook


### PR DESCRIPTION
## Summary

- build the static Storybook before publishing it to GitHub Pages
- prevent `gh-pages` from failing when `storybook-static` does not exist

## Verification

- `yarn build-storybook` succeeds with Storybook 10.5.7
- `git diff --check` passes